### PR TITLE
Adding a CMS Lite frame around g-editor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,9 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
+    <!-- FontAwesome CDN link -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w==" crossorigin="anonymous" />
+
     <!-- Gutenberg Styles -->
     <%= htmlWebpackPlugin.options.gutenbergStyle %>
     <!-- End Gutenberg Styles -->

--- a/src/core/style.scss
+++ b/src/core/style.scss
@@ -1,4 +1,8 @@
 
+body {
+  overflow-x: hidden;
+}
+
 @media (min-width: 600px) {
   body .gutenberg__editor {
     position: relative;

--- a/src/core/style.scss
+++ b/src/core/style.scss
@@ -60,7 +60,7 @@ body {
     }
 
     @media (min-width: 783px) {
-      top: 0;
+      top: 118px;
       left: 0;
     }
 

--- a/src/pages/editor.js
+++ b/src/pages/editor.js
@@ -87,23 +87,117 @@ class Editor extends React.Component {
 
     return (
       <React.Fragment>
-        <div className="editor-nav">
-          {
-            ['post', 'page'].map(type => {
-              return (
-                <button
-                  key={ type }
-                  className={ `components-button ${type === postType ? 'is-primary' : ''}` }
-                  onClick={ ev => this.changePostType(ev, types[type].rest_base) }
-                >{ types[type].name }</button>
-              );
-            })
-          }
 
-          <button type="button" className="components-button is-tertiary"
-            onClick={ this.resetLocalStorage }>Clear page and reload</button>
+        {/* Top nav */}
+        <div className="editor-top-frame">
+          <a href="/"><h1>CMS Lite 3.0</h1></a>
+          <div className="nav-buttons">
+            <button className="active-page">Content</button>
+            <button>Form Builder</button>
+            <button>Assets</button>
+            <button>Component Library</button>
+            <button>Search Modules</button>
+          </div>
+          <span />
         </div>
-        <div id="editor" className="gutenberg__editor"></div>
+
+        <div className="editor-main-flex-group">
+
+          {/* Left nav */}
+          <div className="editor-left-frame">
+            <div className="search">
+              <fieldset>
+                <label htmlFor="search">Search by page name or URL</label>
+                <div className="search-input">
+                  <input type="text" id="search"></input>
+                  <button>Search</button>
+                </div>
+              </fieldset>
+            </div>
+            <div className="list-view">
+              <fieldset>
+                <label>List View</label>
+                <select id="list-view">
+                  <option>View all</option>
+                </select>
+              </fieldset>
+            </div>
+            <div className="button-group">
+              <button>Create</button>
+              <button>Lock</button>
+              <button>Move</button>
+              <button>Publish</button>
+              <button>Tag</button>
+              <button>Delete</button>
+            </div>
+            <div className="ia-list">
+              <ul>
+                <li>Theme</li>
+                <ul>
+                  <li>Sub-theme</li>
+                  <li>Sub-theme</li>
+                  <li>Sub-theme</li>
+                  <ul>
+                    <li>Topic</li>
+                  </ul>
+                </ul>
+              </ul>
+            </div>
+          </div>
+
+          {/* Right  */}
+          <div className="editor-right-frame">
+            <div className="editor-right-top-frame">
+              <div className="button-group">
+                <button className="active">Page</button>
+                <button>Settings</button>
+                <button>Metadata</button>
+                <button>Usage</button>
+                <button>Security</button>
+                <button>History</button>
+              </div>
+            </div>
+
+            <div className="editor-gutenberg-container">
+              {/* G-Editor */}
+              <div className="editor-nav">
+                {
+                  ['post', 'page'].map(type => {
+                    return (
+                      <button
+                        key={ type }
+                        className={ `components-button ${type === postType ? 'is-primary' : ''}` }
+                        onClick={ ev => this.changePostType(ev, types[type].rest_base) }
+                      >{ types[type].name }</button>
+                    );
+                  })
+                }
+
+                <button type="button" className="components-button is-tertiary"
+                  onClick={ this.resetLocalStorage }>Clear page and reload</button>
+              </div>
+              <div id="editor" className="gutenberg__editor"></div>
+            </div>
+
+            <div className="editor-right-bottom-frame">
+              <div className="button-group">
+                <div className="flex-spacer">
+                  <button className="active">Edit</button>
+                </div>
+                <div className="flex-spacer">
+                  <button>View Prod</button>
+                  <button>View QA</button>
+                  <button className="icon"><i className="fas fa-eye"></i></button>
+                  <button>Publish</button>
+                  <button>Unpublish</button>
+                  <button className="icon"><i className="fas fa-lock"></i></button>
+                  <button className="icon"><i className="far fa-copy"></i></button>
+                  <button className="icon"><i className="fas fa-link"></i></button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </React.Fragment>
     );
   }

--- a/src/pages/editor.scss
+++ b/src/pages/editor.scss
@@ -6,6 +6,8 @@
   align-items: center;
   width: 100%;
   height: 56px;
+  top: 118px;
+  left: 322px;
 
   * {
     z-index: 99;
@@ -21,4 +23,296 @@
 
 iframe {
   border: none;
+}
+
+.editor-top-frame {
+  border-bottom: 2px solid grey;
+  display: flex;
+  flex-direction: row;
+  font-family: Arial, Helvetica, sans-serif;
+  height: 68px;
+  justify-content: space-between;
+  width: 100%;
+
+  a {
+    color: black;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-decoration: none;
+
+    h1 {
+      display: inline-block;
+      font-size: 15px;
+      margin: 0 0 0 20px;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  div.nav-buttons {
+    display: flex;
+    align-items: center;
+
+    button {
+      background: none;
+      border: 0;
+      border-radius: 0;
+      cursor: pointer;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 18px;
+      font-weight: 900;
+      height: 68px;
+      margin: 0 5px;
+      padding: 0 15px;
+
+      &:hover {
+        background-color: #e6e6e6;
+        text-decoration: underline;
+      }
+
+      &.active-page {
+        background-color: #d0d0d0;
+
+        &:hover {
+          background-color: #e6e6e6;
+        }
+      }
+    }
+  }
+
+  span {
+    margin-left: 200px;
+  }
+}
+
+.editor-main-flex-group {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+}
+
+.editor-left-frame {
+  display: inline-block;
+  height: 100%;
+  max-width: 320px;
+  width: 100%;
+
+  div.search {
+    padding: 15px;
+
+    fieldset {
+      border: 0px;
+      margin: 0;
+      padding: 0;
+
+      label {
+        display: block;
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 13px;
+        margin: 0 0 8px 0;
+      }
+
+      div.search-input {
+        display: flex;
+
+        input[type="text"] {
+          border: 2px solid black;
+          border-radius: 0;
+          flex-grow: 1;
+        }
+
+        button {
+          background-color: black;
+          border: 2px solid black;
+          border-radius: 0;
+          color: white;
+          cursor: pointer;
+          font-family: Arial, Helvetica, sans-serif;
+          font-size: 16px;
+          font-weight: 900;
+          height: 44px;
+          padding: 0 25px;
+
+          &:hover {
+            background-color: #e6e6e6;
+            border-color: #e6e6e6;
+            color: black;
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+  }
+
+  div.list-view {
+    padding: 15px;
+
+    fieldset {
+      border: 0;
+      margin: 0;
+      padding: 0;
+
+      label {
+        display: block;
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 13px;
+      }
+
+      select {
+        border: 2px solid black;
+        cursor: pointer;
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 16px;
+        height: 44px;
+        width: 100%;
+      }
+    }
+  }
+
+  div.button-group {
+    border-top: 2px solid grey;
+    border-bottom: 2px solid grey;
+    display: flex;
+    justify-content: space-between;
+    margin-top: 15px;
+
+    button {
+      background: none;
+      // background-color: white;
+      border: 0;
+      border-radius: 0;
+      cursor: pointer;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 14px;
+      height: 44px;
+
+      &:hover {
+        background-color: #e6e6e6;
+      }
+    }
+  }
+
+  div.ia-list {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 18px;
+
+    :hover {
+      background-color: #e6e6e6;
+      cursor: pointer;
+    }
+  }
+}
+
+.editor-right-frame {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  .editor-right-top-frame {
+    border-bottom: 2px solid grey;
+    width: 100%;
+
+    div.button-group {
+      display: flex;
+      flex-direction: row;
+      height: 44px;
+
+      button {
+        background-color: white;
+        border: 0;
+        border-radius: 0;
+        cursor: pointer;
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 16px;
+        font-weight: 900;
+        padding: 0 53px;
+
+        &.active {
+          background-color: black;
+          color: white;
+        }
+
+        &:hover {
+          background-color: #e6e6e6;
+          color: black;
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+
+  .editor-gutenberg-container {
+    border: 2px solid grey;
+    display: inline-block;
+    height: calc(100vh - 166px);
+
+    &:focus-within {
+      border-color: red;
+    }
+  }
+
+  .editor-right-bottom-frame {
+    border-top: 2px solid grey;
+    bottom: 0;
+    position: static;
+    width: 100%;
+
+    div.button-group {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      height: 44px;
+
+      div.flex-spacer {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+
+        button {
+          background-color: none;
+          border: 0;
+          border-radius: 0;
+          cursor: pointer;
+          font-family: Arial, Helvetica, sans-serif;
+          font-size: 16px;
+          font-weight: 900;
+          margin: 0 5px;
+          padding: 0 40px;
+
+          &.active {
+            background-color: black;
+            color: white;
+          }
+
+          &.icon {
+            min-width: 44px;
+            padding: 0 10px;
+          }
+
+          &:hover {
+            background-color: #e6e6e6;
+            color: black;
+            text-decoration: underline;
+          }
+
+          &:first-child {
+            margin-left: 0;
+          }
+          &:last-child {
+            margin-right: 0;
+          }
+        }
+      }
+    }
+  }
+}
+
+// Position the editor within our CMS Lite frame
+body.is-fullscreen-mode .interface-interface-skeleton {
+  bottom: 48px;
+  left: 322px !important; // Over-write the WP editor's left: 0px
+  right: 2px;
 }


### PR DESCRIPTION
This PR takes the forked [g-editor repo](https://github.com/front/g-editor) and adds CMS Lite-specific navigation components around the editor panel to act as a clickable prototype for user research testing.

Notes:
- FontAwesome's CDN link is added to the React static `index.html` file
- The Gutenberg instance is normally displayed full-screen with static positioning, so efforts are made to position it with `top`, `bottom`, and `left` all explicitly set with pixel values

Screenshot:
<img width="1679" alt="Screenshot of last commit state in Chrome running on macOS" src="https://user-images.githubusercontent.com/25143706/113958722-69dfc400-97d6-11eb-80e8-70a594f58066.png">