### PR TITLE
TreeView component

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   ],
   "dependencies": {
     "@babel/core": "7.2.2",
+    "@material-ui/core": "^4.11.3",
+    "@material-ui/lab": "^4.0.0-alpha.57",
     "@svgr/webpack": "2.4.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "9.0.0",

--- a/src/components/Dropdown.scss
+++ b/src/components/Dropdown.scss
@@ -17,6 +17,7 @@
     margin: 0;
     padding: 0;
     position: fixed;
+    z-index: 1;
 
     &.collapsed {
       display: none;

--- a/src/components/TreeView.js
+++ b/src/components/TreeView.js
@@ -1,0 +1,40 @@
+// From Material UI: https://material-ui.com/components/tree-view/
+
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import TreeView from '@material-ui/lab/TreeView';
+import TreeItem from '@material-ui/lab/TreeItem';
+
+const useStyles = makeStyles({
+  root: {
+    height: 110,
+    flexGrow: 1,
+    maxWidth: 400,
+    overflowX: "auto",
+    overflowY: "auto",
+    padding: 13,
+  },
+});
+
+function RecursiveTreeView({ data }) {
+  const classes = useStyles();
+
+  const renderTree = (nodes) => (
+    <TreeItem key={nodes.id} nodeId={nodes.id} label={nodes.name}>
+      {Array.isArray(nodes.children) ? nodes.children.map((node) => renderTree(node)) : null}
+    </TreeItem>
+  );
+
+  return (
+    <TreeView
+      className={classes.root}
+      defaultCollapseIcon={<i className="fas fa-chevron-down"></i>}
+      defaultExpanded={['root']}
+      defaultExpandIcon={<i className="fas fa-chevron-right"></i>}
+    >
+      {renderTree(data)}
+    </TreeView>
+  );
+}
+
+export { RecursiveTreeView };

--- a/src/core/style.scss
+++ b/src/core/style.scss
@@ -1,6 +1,6 @@
 
 body {
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 @media (min-width: 600px) {

--- a/src/pages/editor.js
+++ b/src/pages/editor.js
@@ -3,6 +3,7 @@ import types from '../data/types';
 import { changeType } from '../globals/fake-data';
 
 import { Dropdown } from '../components/Dropdown';
+import { RecursiveTreeView } from '../components/TreeView';
 
 import './editor.scss';
 
@@ -107,6 +108,8 @@ class Editor extends React.Component {
 
           {/* Left nav */}
           <div className="editor-left-frame">
+
+            {/* Search */}
             <div className="search">
               <fieldset>
                 <label htmlFor="search">Search by page name or URL</label>
@@ -116,6 +119,8 @@ class Editor extends React.Component {
                 </div>
               </fieldset>
             </div>
+
+            {/* List view */}
             <div className="list-view">
               <fieldset>
                 <label>List View</label>
@@ -124,8 +129,9 @@ class Editor extends React.Component {
                 </select>
               </fieldset>
             </div>
+
+            {/* Page action buttons */}
             <div className="button-group">
-              {/* <button>Create</button> */}
               <Dropdown
                 label="Create"
                 items={[
@@ -146,18 +152,59 @@ class Editor extends React.Component {
               />
               <button>Delete</button>
             </div>
-            <div className="ia-list">
-              <ul>
-                <li>Theme</li>
-                <ul>
-                  <li>Sub-theme</li>
-                  <li>Sub-theme</li>
-                  <li>Sub-theme</li>
-                  <ul>
-                    <li>Topic</li>
-                  </ul>
-                </ul>
-              </ul>
+
+            {/* IA tree view should take up remaining vertical space */}
+            <div className="ia-flex-container">
+              <RecursiveTreeView
+                data={
+                  {
+                    id: 'root',
+                    name: 'Theme',
+                    children: [
+                      {
+                        id: 'sub-theme-1',
+                        name: 'Sub-theme 1',
+                      },
+                      {
+                        id: 'sub-theme-2',
+                        name: 'Sub-theme 2',
+                        children: [
+                          {
+                            id: 'topic-1',
+                            name: 'Topic',
+                          },
+                        ],
+                      },
+                      {
+                        id: 'sub-theme-3',
+                        name: 'Sub-theme 3',
+                        children: [
+                          {
+                            id: 'topic-1',
+                            name: 'Topic 2',
+                            children: [
+                              {
+                                id: 'topic-2a',
+                                name: 'Topic 2a',
+                                children: [
+                                  {
+                                    id: 'topic-2a1',
+                                    name: 'Topic 2a1',
+                                  },
+                                  {
+                                    id: 'topic-2a2',
+                                    name: 'Topic 2a2',
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  }
+                }
+              />
             </div>
           </div>
 

--- a/src/pages/editor.scss
+++ b/src/pages/editor.scss
@@ -195,14 +195,12 @@ iframe {
     }
   }
 
-  div.ia-list {
+  div.ia-flex-container {
+    display: flex;
+    flex-direction: column;
     font-family: Arial, Helvetica, sans-serif;
     font-size: 18px;
-
-    :hover {
-      background-color: #e6e6e6;
-      cursor: pointer;
-    }
+    height: calc(100vh - 327px);
   }
 }
 

--- a/src/pages/editor.scss
+++ b/src/pages/editor.scss
@@ -159,6 +159,7 @@ iframe {
         display: block;
         font-family: Arial, Helvetica, sans-serif;
         font-size: 13px;
+        margin: 0 0 8px 0;
       }
 
       select {


### PR DESCRIPTION
This pull request adds a TreeView component using the [Material UI Lab TreeView](https://material-ui.com/components/tree-view/). An instance of it is added to the editor frame in the lower left of the screen for use as an IA hierarchy tree in the application. It's set to take up the remaining lower left corner of the screen, with internal scrolling for overflow.

New dependencies:
- [@material-ui/core](https://www.npmjs.com/package/@material-ui/core)
- [@material-ui/lab](https://www.npmjs.com/package/@material-ui/lab)

<img width="1679" alt="Application screenshot with TreeView component in lower portion of left-hand frame" src="https://user-images.githubusercontent.com/25143706/114246884-a7fcf500-9948-11eb-9826-86fcc76ec5c8.png">

